### PR TITLE
Change items parameter to a string

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -138,8 +138,16 @@ class PurchaseRequest extends AbstractRequest
         $transaction->addChild('var1', $this->getExtraData1());
         $transaction->addChild('var2', $this->getExtraData2());
         $transaction->addChild('var3', $this->getExtraData3());
-        $transaction->addChild('items', $this->getItems());
         $transaction->addChild('gateway', $this->getGateway());
+
+        if ($items = $this->getItems()) {
+            $itemsHtml = '<ul>';
+            foreach ($items as $item) {
+                $itemsHtml .= "<li>{$item['quantity']} x {$item['name']}</li>";
+            }
+            $itemsHtml .= '</ul>';
+            $transaction->addChild('items', $itemsHtml);
+        }
 
         if ('IDEAL' === $this->getGateway() && $this->getIssuer()) {
             $gatewayInfo = $data->addChild('gatewayinfo');

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -32,7 +32,10 @@ class PurchaseRequestTest extends TestCase
             'extraData2' => 'extra 2',
             'extraData3' => 'extra 3',
             'language' => 'a language',
-            'items' => 'the items',
+            'items' => array(
+                array('name' => 'item 1', 'quantity' => 1),
+                array('name' => 'item 2', 'quantity' => 2)
+            ),
             'clientIp' => '127.0.0.1',
             'googleAnalyticsCode' => 'analytics code',
             'card' => array(
@@ -165,8 +168,8 @@ class PurchaseRequestTest extends TestCase
     <var1>extra 1</var1>
     <var2>extra 2</var2>
     <var3>extra 3</var3>
-    <items>the items</items>
     <gateway>IDEAL</gateway>
+    <items>&lt;ul&gt;&lt;li&gt;1 x item 1&lt;/li&gt;&lt;li&gt;2 x item 2&lt;/li&gt;&lt;/ul&gt;</items>
   </transaction>
   <gatewayinfo>
     <issuerid>issuer</issuerid>
@@ -216,8 +219,8 @@ EOF;
     <var1>extra 1</var1>
     <var2>extra 2</var2>
     <var3>extra 3</var3>
-    <items>the items</items>
     <gateway>another</gateway>
+    <items>&lt;ul&gt;&lt;li&gt;1 x item 1&lt;/li&gt;&lt;li&gt;2 x item 2&lt;/li&gt;&lt;/ul&gt;</items>
   </transaction>
   <signature>ad447bab87b8597853432c891e341db1</signature>
 </redirecttransaction>
@@ -264,8 +267,8 @@ EOF;
     <var1>extra 1</var1>
     <var2>extra 2</var2>
     <var3>extra 3</var3>
-    <items>the items</items>
     <gateway>IDEAL</gateway>
+    <items>&lt;ul&gt;&lt;li&gt;1 x item 1&lt;/li&gt;&lt;li&gt;2 x item 2&lt;/li&gt;&lt;/ul&gt;</items>
   </transaction>
   <gatewayinfo>
     <issuerid>issuer</issuerid>


### PR DESCRIPTION
When submitting a purchase request with line items – which is an array – you get `SimpleXMLElement::addChild() expects parameter 2 to be string, array given`.

The [MultiSafepay docs](https://multisafepay.com/downloads/handleidingen/Handleiding_connect(ENG).pdf) request a string, and their code examples suggest to construct a `ul`.

``` php
$msp->transaction['items'] = '<br/><ul><li>1 x Item1</li><li>2 x Item2</li></ul>';
```

The `ul` displays nicely in their checkout process and in their emails.

