### PR TITLE
Wrap items in htmlspecialchars

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -146,7 +146,7 @@ class PurchaseRequest extends AbstractRequest
                 $itemsHtml .= "<li>{$item['quantity']} x {$item['name']}</li>";
             }
             $itemsHtml .= '</ul>';
-            $transaction->addChild('items', $itemsHtml);
+            $transaction->addChild('items', htmlspecialchars($itemsHtml));
         }
 
         if ('IDEAL' === $this->getGateway() && $this->getIssuer()) {


### PR DESCRIPTION
Line items containing `&` would break the XML generation, they don't get encoded automatically.