### PR TITLE
Changed 'disable_send_mail' to 'disable_send_email'

### DIFF
--- a/src/Message/RestPurchaseRequest.php
+++ b/src/Message/RestPurchaseRequest.php
@@ -337,7 +337,7 @@ class RestPurchaseRequest extends RestAbstractRequest
      */
     public function getSendMail()
     {
-        return $this->getParameter('disable_send_mail');
+        return $this->getParameter('disable_send_email');
     }
 
     /**
@@ -351,7 +351,7 @@ class RestPurchaseRequest extends RestAbstractRequest
      */
     public function setSendMail($value)
     {
-        return $this->setParameter('disable_send_mail', $value);
+        return $this->setParameter('disable_send_email', $value);
     }
 
     /**
@@ -411,7 +411,7 @@ class RestPurchaseRequest extends RestAbstractRequest
     public function getCustomerData()
     {
         $data = array(
-            'disable_send_mail' => $this->getSendMail(),
+            'disable_send_email' => $this->getSendMail(),
             'locale'            => $this->getLocale(),
         );
 


### PR DESCRIPTION
Changed 'disable_send_mail' to 'disable_send_email' to comply to the official MultiSafepay API documentation (https://www.multisafepay.com/documentation/doc/API-Reference/).

I haven't been able to test this since we were planning on using this with bank transfer but it hasn't been implemented (yet) for bank transfers (we've got an pending request on this at multisafepay). But as it's documented in the official API documentation I think we can presume it should be 'disable_send_email'.