### PR TITLE
Implement FetchPaymentMethodsResponseInterface in FetchPaymentMethodsResponse

### DIFF
--- a/src/Message/FetchPaymentMethodsResponse.php
+++ b/src/Message/FetchPaymentMethodsResponse.php
@@ -5,13 +5,16 @@
 
 namespace Omnipay\MultiSafepay\Message;
 
+use Omnipay\Common\Message\FetchPaymentMethodsResponseInterface;
+use Omnipay\Common\PaymentMethod;
+
 /**
  * MultiSafepat XML Api Fetch Payment Methods Response.
  *
  * @deprecated This API is deprecated and will be removed in
  * an upcoming version of this package. Please switch to the Rest API.
  */
-class FetchPaymentMethodsResponse extends AbstractResponse
+class FetchPaymentMethodsResponse extends AbstractResponse implements FetchPaymentMethodsResponseInterface
 {
     /**
      * {@inheritdoc}
@@ -28,10 +31,10 @@ class FetchPaymentMethodsResponse extends AbstractResponse
      */
     public function getPaymentMethods()
     {
-        $result = array();
+        $result = [];
 
         foreach ($this->data->gateways->gateway as $gateway) {
-            $result[(string) $gateway->id] = (string) $gateway->description;
+            $result[] = new PaymentMethod((string) $gateway->id, (string) $gateway->description);
         }
 
         return $result;

--- a/tests/Message/XmlFetchPaymentMethodsRequestTest.php
+++ b/tests/Message/XmlFetchPaymentMethodsRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\MultiSafepay\Message;
 
+use Omnipay\Common\PaymentMethod;
 use Omnipay\Tests\TestCase;
 
 class XmlFetchPaymentMethodsRequestTest extends TestCase
@@ -66,17 +67,17 @@ class XmlFetchPaymentMethodsRequestTest extends TestCase
 
     public function paymentMethodsProvider()
     {
-        return array(
-            array(
-                array(
-                    'VISA' => 'Visa CreditCards',
-                    'WALLET' => 'MultiSafepay',
-                    'IDEAL' => 'iDEAL',
-                    'BANKTRANS' => 'Bank Transfer',
-                    'MASTERCARD' => 'MasterCard',
-                ),
-            ),
-        );
+        return [
+            [
+                [
+                    new PaymentMethod('VISA', 'Visa CreditCards'),
+                    new PaymentMethod('WALLET', 'MultiSafepay'),
+                    new PaymentMethod('IDEAL', 'iDEAL'),
+                    new PaymentMethod('BANKTRANS', 'Bank Transfer'),
+                    new PaymentMethod('MASTERCARD', 'MasterCard'),
+                ],
+            ],
+        ];
     }
 
     public function dataProvider()


### PR DESCRIPTION
Ensure that the (deprecated) xml FetchPaymentMethodsResponse implements the corresponding FetchPaymentMethodsResponseInterface.

Note that this is a BC break.