### PR TITLE
Update RestCompletePurchaseResponse.php

### DIFF
--- a/src/Message/RestCompletePurchaseResponse.php
+++ b/src/Message/RestCompletePurchaseResponse.php
@@ -27,4 +27,12 @@ class RestCompletePurchaseResponse extends RestFetchTransactionResponse
     {
         return $this->getPaymentStatus() == 'completed';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPending()
+    {
+        return parent::isInitialized();
+    }
 }


### PR DESCRIPTION
'Initialized' transactions should be treated as pending.
Problem occurs with Ideal payments that get the status 'open completed'.
Webhooks will send the 'completed' response later but the initial response should be treated as pending 

see https://github.com/craftcms/commerce-multisafepay/issues/2