### PR TITLE
Fixed use uppercase for http request method

### DIFF
--- a/src/Message/RestAbstractRequest.php
+++ b/src/Message/RestAbstractRequest.php
@@ -153,7 +153,7 @@ abstract class RestAbstractRequest extends AbstractRequest
     protected function sendRequest($method, $endpoint, $data = null)
     {
         return $this->httpClient->request(
-            $method,
+            strtoupper($method),
             $this->getEndpoint() . $endpoint,
             $this->getHeaders(),
             $data


### PR DESCRIPTION
Symfony checkes if the request method is uppercase and throws an error if it is not: 

    Invalid HTTP method "get", only uppercase letters are accepted.